### PR TITLE
Remove service accounts endpoints

### DIFF
--- a/yepcode_run/api/types.py
+++ b/yepcode_run/api/types.py
@@ -470,22 +470,6 @@ class CreateStorageObjectInput:
     file: Any
 
 
-# Service account types
-@dataclass
-class ServiceAccount:
-    id: str
-    name: str
-    client_id: str
-    client_secret: Optional[str] = None
-    created_at: Optional[datetime] = None
-    updated_at: Optional[datetime] = None
-
-
-@dataclass
-class ServiceAccountInput:
-    name: str
-
-
 # Dependency manifest types
 @dataclass
 class ProgrammingLanguageManifest:

--- a/yepcode_run/api/yepcode_api.py
+++ b/yepcode_run/api/yepcode_api.py
@@ -42,8 +42,6 @@ from .types import (
     ScheduledProcessInput,
     CreateStorageObjectInput,
     StorageObject,
-    ServiceAccount,
-    ServiceAccountInput,
     ProgrammingLanguage,
     ProgrammingLanguageManifest,
     UpdateTeamDependenciesInput,
@@ -525,15 +523,6 @@ class YepCodeApi:
 
     def update_schedule(self, id: str, data: ScheduledProcessInput) -> Schedule:
         return self._request("PATCH", f"/schedules/{id}", {"data": data})
-
-    def get_service_accounts(self) -> List[ServiceAccount]:
-        return self._request("GET", "/auth/service-accounts")
-
-    def create_service_account(self, data: ServiceAccountInput) -> ServiceAccount:
-        return self._request("POST", "/auth/service-accounts", {"data": data})
-
-    def delete_service_account(self, id: str) -> None:
-        self._request("DELETE", f"/auth/service-accounts/{id}")
 
     def get_team_dependencies(
         self, language: ProgrammingLanguage


### PR DESCRIPTION
## Summary

- Remove `GET /auth/service-accounts`, `POST /auth/service-accounts`, and `DELETE /auth/service-accounts/{id}` methods from `YepCodeApi`
- Remove corresponding `ServiceAccount` and `ServiceAccountInput` type imports and dataclass definitions from `types.py`

These endpoints have been removed from the OpenAPI spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)